### PR TITLE
Issue #1 add text for bfd subcode

### DIFF
--- a/draft-ietf-idr-bgp-bfd-strict-mode.xml
+++ b/draft-ietf-idr-bgp-bfd-strict-mode.xml
@@ -191,7 +191,7 @@
         is not Established state, then the BGP will close the session.
       </t>
       <t>
-        If the BFD Stict-Mode is enabled or disabled for a BGP peer and the BGP session
+        If the BFD strict-mode is enabled or disabled for a BGP peer and the BGP session
         state is Established state, the local BFD strict-mode configuration will be modified but the session
         will remain in Established state.
       </t>
@@ -202,6 +202,16 @@
         To avoid this situation, BFD strict-mode SHOULD be modified
         consistently on both the local and remote BGP peers.
       </t>
+      <section numbered="true" toc="default">
+        <name>Closing BGP Sessions</name>
+        <t>
+          When BGP sessions are closed according to the procedures in this document, the session
+          should be terminated with a NOTIFICATION message with the Cease Code and the "BFD Down"
+          Subcode. (<xref target="I-D.ietf-idr-bfd-subcode"/>)  This informs the operator that
+          interaction with BFD is the root cause of the BGP session being unable to move to the
+          Established state.
+        </t>
+      </section>
       <section numbered="true" toc="default">
         <name>Stability Considerations</name>
         <t>
@@ -263,6 +273,7 @@
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5880.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5882.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-idr-bfd-subcode.xml"/>
     </references>
   </back>
 </rfc>


### PR DESCRIPTION
The session goes down for BFD reasons and we should indicate that. It avoids ambiguity of using BGP holdtime expired errors when it's actually because of BFD interaction that we're having issues.

Closes #1